### PR TITLE
Require at least v0.14.0 of future. Added travis config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+# commands to install dependencies
+install:
+  - python setup.py -q install
+# commands to run tests
+script:
+  - python test.py

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/setup.py
+++ b/setup.py
@@ -30,5 +30,5 @@ setup(
     'Programming Language :: Python :: 3.2',
     'Programming Language :: Python :: 3.3',
     ],
-    install_requires=['future'],
+    install_requires=['future>=0.14.0'],
 )


### PR DESCRIPTION
Hi @gkovacs,

Many thanks for your work on this package, it's a great help to have it work for all versions of Python and available on PyPI.

I ran into a strange bug yesterday where I was getting the following ImportError when including the module:

```python
Traceback (most recent call last):
  File "test_simple.py", line 3, in <module>
    import lzstring
  File "/Users/philewels/GitHub/lz-string-python/lzstring/__init__.py", line 8, in <module>
    from builtins import range
ImportError: No module named builtins
```

After scratching my head for a while, I figured out that it was because I had an old version of the `future` module installed (`v0.13.1`). Upgrading to `v0.14.0` or above seems to solve this import error.

To prevent other people running into this problem, I've updated `setup.py` so that the installation requires at least `v0.14.0` of the `future` module.

I've also added a `.travis.yml` file to enable continuous integration for multiple versions of Python. For an example, see https://travis-ci.org/ewels/lz-string-python (happy to remove this from the PR if you'd rather not have it).

Phil