### PR TITLE
Added MANIFEST.in file for PyPI packaging of licence and readme.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE.md
+include README.rst


### PR DESCRIPTION
Added `MANIFEST.in` - ensures that the PyPI distribution ships with `LICENCE.md` and `README.rst`. See request from conda admins in https://github.com/gkovacs/lz-string-python/pull/2#issuecomment-302616553