### PR TITLE
Fixes decompression of base64 strings originated from JS compressor i…

### DIFF
--- a/lzstring/__init__.py
+++ b/lzstring/__init__.py
@@ -527,12 +527,18 @@ class LZString(object):
             power = 1
 
             while power != maxpower:
-                resb = data_val & data_position
+                if data_val is not None:
+                    resb = data_val & data_position
+                else:
+                    resb = 0
                 data_position >>= 1
 
                 if data_position == 0:
                     data_position = 32768
-                    data_val = ord(data_string[data_index])
+                    if data_index < len(data_string):
+                        data_val = ord(data_string[data_index])
+                    else:
+                        data_val = None
                     data_index += 1
 
                 bits |= (1 if resb > 0 else 0) * power
@@ -555,12 +561,18 @@ class LZString(object):
             power = 1
 
             while power != maxpower:
-                resb = data_val & data_position
+                if data_val is not None:
+                    resb = data_val & data_position
+                else:
+                    resb = 0
                 data_position >>= 1
 
                 if data_position == 0:
                     data_position = 32768
-                    data_val = ord(data_string[data_index])
+                    if data_index < len(data_string):
+                        data_val = ord(data_string[data_index])
+                    else:
+                        data_val = None
                     data_index += 1
 
                 bits |= (1 if resb > 0 else 0) * power


### PR DESCRIPTION
The original Python code simply copies the structure of the original JS code.
However, the JS code only works, because at the end of the array, when it increases the data.index value beyond its length, the str.charCodeAt(index) function returns NaN. The not value is in the next iteration combined using bitewise AND operator with data.position to produce numerical 0.
This change reproduces this ingenious /s JS behaviour in Python.

Example:
on the JS console of the lz-string demo page produce this compressed content:
    LZString144.compressToBase64("ahoj")
    "IYCw9gVkA==="

If you try to decompress this output with the Python version of the lzstring library, you'll get following error:
    $ python3 -c 'from lzstring import LZString; lz=LZString(); print(lz.decompressFromBase64("IYCw9gVkA==="))'
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/usr/local/lib/python3.4/dist-packages/lzstring/__init__.py", line 685, in decompressFromBase64
       return self.decompress(output)
      File "/usr/local/lib/python3.4/dist-packages/lzstring/__init__.py", line 563, in decompress
        data_val = ord(data_string[data_index])

With the fix introduced here the decompression succeeds:
    $ python3 -c 'from lzstring import LZString; lz=LZString(); print(lz.decompressFromBase64("IYCw9gVkA==="))'
    ahoj