### PR TITLE
Implement Uint8 encoding/decoding

### DIFF
--- a/lzstring/__init__.py
+++ b/lzstring/__init__.py
@@ -50,7 +50,10 @@ def _compress(uncompressed, bitsPerChar, getCharFromInt):
     context_data_position = 0
 
     for ii in range(len(uncompressed)):
-        context_c = uncompressed[ii]
+        if isinstance(uncompressed, (bytes)):
+            context_c = chr(uncompressed[ii])
+        else:
+            context_c = uncompressed[ii]
         if context_c not in context_dictionary:
             context_dictionary[context_c] = context_dictSize
             context_dictSize += 1
@@ -374,6 +377,11 @@ class LZString(object):
         return _compress(uncompressed, 16, chr)
 
     @staticmethod
+    def compressToUint8Array(uncompressed):
+        return bytes([ord(x) for x in _compress(uncompressed, 8, chr)])
+
+
+    @staticmethod
     def compressToUTF16(uncompressed):
         if uncompressed is None:
             return ""
@@ -403,6 +411,14 @@ class LZString(object):
         if compressed == "":
             return None
         return _decompress(len(compressed), 32768, lambda index: ord(compressed[index]))
+
+    @staticmethod
+    def decompressFromUint8Array(compressed):
+        if compressed is None:
+            return ""
+        if compressed == "":
+            return None
+        return _decompress(len(compressed), 128, lambda index: compressed[index])
 
     @staticmethod
     def decompressFromUTF16(compressed):


### PR DESCRIPTION
compressToUint8Array
decompressToUint8Array

This is the best I could do without doing a bigger rewrite so lzstringn
doesn't use the str() type and use bytes() (or another type).  str()
have lot of issues with conversions.

This wont work in python 2