### PR TITLE
Python 3.12 fix

### DIFF
--- a/lzstring/__init__.py
+++ b/lzstring/__init__.py
@@ -8,8 +8,6 @@ from __future__ import absolute_import
 from builtins import range
 from builtins import int
 from builtins import chr
-from future import standard_library
-standard_library.install_aliases()
 from builtins import object
 import math
 import re


### PR DESCRIPTION
Fix compatibility with Python 3.12:

```
  File "/miniconda3/envs/py3.12/lib/python3.12/site-packages/lzstring/__init__.py", line 11, in <module>
    from future import standard_library
  File "/miniconda3/envs/py3.12/lib/python3.12/site-packages/future/standard_library/__init__.py", line 65, in <module>
    import imp
ModuleNotFoundError: No module named 'imp'
```

(from https://github.com/ewels/MultiQC/issues/2112#issue-1939704621)

This breaks Python 2 compatibility though, so probably could be a good excuse to get rid of the Python 2 code? 😄 